### PR TITLE
Support multiple files with `azsync file`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 mod app;
-mod blobs;
 mod completions;
 mod dotenv;
+mod file;
 mod global;
 mod key_vault;
 mod maybe_env;
@@ -9,9 +9,9 @@ mod storage;
 mod sync;
 
 pub use app::*;
-pub use blobs::*;
 pub use completions::*;
 pub use dotenv::*;
+pub use file::*;
 pub use global::*;
 pub use key_vault::*;
 pub use maybe_env::*;

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -44,7 +44,7 @@ pub enum CliCommand {
     /// you when either pushing or pulling variables.
     Dotenv(SyncDotenvOptions),
 
-    /// Synchronize a file with Azure.
+    /// Synchronize files with Azure.
     File(SyncFileOptions),
 }
 

--- a/src/cli/file.blob_name.txt
+++ b/src/cli/file.blob_name.txt
@@ -1,0 +1,16 @@
+The name of the remote blob.
+
+If not provided, the name of the file being synchronized is used as the blob name instead.
+
+The blob name can either be a standard blob name or a pattern. Note that if you are synchronizing multiple files, then a pattern must be provided instead.
+
+Patterns support the following placeholders:
+
+- #name#: The name of the file (without its directory)
+  - Example: /foo/bar/baz.tar.gz -> baz.tar.gz
+- #ext#: The file extension (final suffix, excluding dot prefixes)
+  - Example: /foo/bar/baz.tar.gz -> gz
+  - Example: .env -> (no extension, exit with error)
+- #stem#: The portion of the name that is not the extension
+  - Example: /foo/bar/baz.tar.gz -> baz.tar
+  - Example: .env -> .env

--- a/src/cli/file.blob_name.txt
+++ b/src/cli/file.blob_name.txt
@@ -8,9 +8,12 @@ Patterns support the following placeholders:
 
 - #name#: The name of the file (without its directory)
   - Example: /foo/bar/baz.tar.gz -> baz.tar.gz
-- #ext#: The file extension (final suffix, excluding dot prefixes)
-  - Example: /foo/bar/baz.tar.gz -> gz
-  - Example: .env -> (no extension, exit with error)
-- #stem#: The portion of the name that is not the extension
+- #stem#: The portion of the name that is not the suffix
   - Example: /foo/bar/baz.tar.gz -> baz.tar
   - Example: .env -> .env
+- #suffix#: The file extension (final suffix, including dot)
+  - Example: /foo/bar/baz.tar.gz -> .gz
+  - Example: .env -> "" (no extension)
+- #ext#: The file extension (final suffix, excluding dot)
+  - Example: /foo/bar/baz.tar.gz -> gz
+  - Example: .env -> "" (no extension)

--- a/src/cli/file.rs
+++ b/src/cli/file.rs
@@ -8,6 +8,25 @@ use crate::cli::{AzureStorageOptions, SyncOptions};
 #[derive(Clone, Debug, Args)]
 pub struct SyncFileOptions {
     /// The files to sync.
+    ///
+    /// NOTE ON GLOBBING (*.json):
+    ///
+    /// On most shells, globs are expanded by the shell. For example, the path
+    /// *.json will usually be converted by your shell into a list of all files
+    /// matching that pattern (like foo.json bar.json). When shells expand these
+    /// patterns, THEY ONLY INCLUDE FILES ON YOUR SYSTEM. Applications do not
+    /// receive the pattern. They only receive the list of paths that matched it
+    /// so they have no way of knowing what the pattern was.
+    ///
+    /// As a result, if you want to synchronize a file that does not exist on
+    /// your system, you MUST specify it literally. For example, if you want to
+    /// pull the file foo.json, you MUST specify foo.json because *.json will
+    /// not be expanded by your shell to include it.
+    ///
+    /// There is currently no way to pull all files matching a pattern from the
+    /// remote storage. IF YOU WANT TO SYNCHRONIZE A DIRECTORY, ARCHIVE IT
+    /// FIRST. You can synchronize foos.zip easily because it is only one file.
+    #[arg(required = true, num_args = 1..)]
     pub paths: Vec<PathBuf>,
 
     // NOTE: clap doesn't format doc comments correctly for long help yet:

--- a/src/cli/file.rs
+++ b/src/cli/file.rs
@@ -7,15 +7,19 @@ use crate::cli::{AzureStorageOptions, SyncOptions};
 /// Options for synchronizing files.
 #[derive(Clone, Debug, Args)]
 pub struct SyncFileOptions {
-    /// The file to sync.
-    pub path: PathBuf,
+    /// The files to sync.
+    pub paths: Vec<PathBuf>,
 
-    /// The name of the remote blob.
-    ///
-    /// If not provided, the name of the file being synchronized is used as the
-    /// blob name instead.
-    #[arg(long)]
-    pub blob_name: Option<String>,
+    // NOTE: clap doesn't format doc comments correctly for long help yet:
+    // https://github.com/clap-rs/clap/issues/5900
+    #[doc = include_str!("file.blob_name.txt")]
+    #[arg(
+        long,
+        default_value = "#name#",
+        help = "The name of the remote blob.",
+        long_help = include_str!("file.blob_name.txt"),
+    )]
+    pub blob_name: String,
 
     /// Options for configuring how to synchronize with Azure.
     #[command(flatten)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod macros;
+
 mod command;
 mod completions;
 mod dotenv;

--- a/src/commands/dotenv.rs
+++ b/src/commands/dotenv.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::{Ordering, max},
+    cmp::max,
     collections::{HashMap, HashSet},
     fs::File,
     future::ready,
@@ -232,34 +232,12 @@ pub struct PullVar {
     pairs_tx: Sender<(String, String)>,
 }
 
+sortable_by_key!(PullVar, str, |action| &action.name);
+
 impl SyncAction for PullVar {
     async fn execute(self) -> anyhow::Result<()> {
         self.pairs_tx.send((self.name, self.value))?;
         Ok(())
-    }
-}
-
-impl PartialEq for PullVar {
-    fn eq(&self, other: &Self) -> bool {
-        // Only compare names so only the name is used when sorting
-        self.name == other.name
-    }
-}
-
-// Technically this forms a total equality relationship
-impl Eq for PullVar {}
-
-impl PartialOrd for PullVar {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // Only compare names
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PullVar {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Technically forms a total ordering on the names
-        self.name.cmp(&other.name)
     }
 }
 
@@ -268,6 +246,8 @@ pub struct PushVar {
     value: String,
     client: Arc<SecretClient>,
 }
+
+sortable_by_key!(PushVar, str, |action| &action.name);
 
 impl SyncAction for PushVar {
     async fn execute(self) -> anyhow::Result<()> {
@@ -283,29 +263,5 @@ impl SyncAction for PushVar {
             .await?;
 
         Ok(())
-    }
-}
-
-impl PartialEq for PushVar {
-    fn eq(&self, other: &Self) -> bool {
-        // Only compare names so only the name is used when sorting
-        self.name == other.name
-    }
-}
-
-// Technically this forms a total equality relationship
-impl Eq for PushVar {}
-
-impl PartialOrd for PushVar {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // Only compare names
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PushVar {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Technically forms a total ordering on the names
-        self.name.cmp(&other.name)
     }
 }

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -133,6 +133,11 @@ impl Command for SyncFileOptions {
             },
         )?;
 
+        // Check if any names are invalid
+        if blob_names.iter().any(String::is_empty) {
+            bail!("Empty blob names are not allowed");
+        }
+
         // Check if we had duplicate names
         if !duplicate_names.is_empty() {
             // Format the names

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -1,17 +1,19 @@
 use std::{
+    collections::HashSet,
     fs::File,
     io::{ErrorKind, Write},
     path::PathBuf,
     process::exit,
+    sync::Arc,
 };
 
-use anyhow::{Context, bail};
+use anyhow::{Context as _, bail};
 use azure_identity::DefaultAzureCredential;
 use azure_storage_blob::{
     BlobClient,
     models::{BlobClientDownloadResultHeaders, BlockBlobClientUploadOptions},
 };
-use futures::TryStreamExt;
+use futures::{TryStreamExt, stream::FuturesUnordered};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::fs::File as AsyncFile;
 use tracing::info;
@@ -19,9 +21,10 @@ use typespec_client_core::{
     fs::FileStreamBuilder,
     http::{StatusCode, response::ResponseBody},
 };
+use url::Url;
 
 use crate::{
-    cli::{GlobalOptions, SyncFileOptions},
+    cli::{GlobalOptions, SyncFileOptions, SyncMode},
     commands::Command,
     dotenv::DotenvFile,
     sync::{SyncAction, SyncType, confirm},
@@ -37,21 +40,101 @@ impl Command for SyncFileOptions {
         } else {
             DotenvFile::from_path_exists(&global_options.env_file)?
         };
-        let local_path = match self.path.canonicalize() {
-            Ok(path) => path,
-            // File doesn't exist yet, so can't be canonicalized
-            Err(error) if error.kind() == ErrorKind::NotFound => self.path,
-            // Other type of I/O error
-            Err(error) => bail!(error),
-        };
-        let blob_name = self
-            .blob_name
-            .as_ref()
-            .map(AsRef::as_ref)
-            .or_else(|| local_path.file_name().and_then(|s| s.to_str()))
-            .context("Blob name cannot be created from paths that are not UTF-8. Please provide a blob name.")?;
 
-        // Create client
+        // De-dupe the input paths to better support shell-level globbing
+        let paths: HashSet<_> = self
+            .paths
+            .into_iter()
+            .map(|path| {
+                match path.canonicalize() {
+                    Ok(path) => Ok(path),
+                    // File doesn't exist yet, so can't be canonicalized
+                    Err(error) if error.kind() == ErrorKind::NotFound => Ok(path),
+                    // Other type of I/O error
+                    Err(error) => Err(error),
+                }
+            })
+            .collect::<Result<_, _>>()?;
+
+        // Convert to an ordered list so that we can track associated blob names
+        let paths = Vec::from_iter(paths);
+
+        // Ensure all blob names are unique
+        let (blob_names, duplicate_names) = paths.iter().try_fold(
+            (
+                Vec::with_capacity(paths.len()),
+                HashSet::with_capacity(paths.len()),
+            ),
+            |(mut blob_names, mut duplicates), path| -> anyhow::Result<_> {
+                // Get path parts
+                let mut name = path
+                    .file_name()
+                    .context("Expected path to file")
+                    .and_then(|name| name.to_str().context("File name must be valid Unicode"));
+                let mut stem = path
+                    .file_stem()
+                    .context("Expected path to file")
+                    .and_then(|stem| stem.to_str().context("File stem must be valid Unicode"));
+                let mut ext = path
+                    .extension()
+                    .context("No file extension")
+                    .and_then(|ext| ext.to_str().context("File extension must be valid Unicode"));
+
+                /// Tries to copy the `Ok` variant out of a result.
+                ///
+                /// This replaces the result with `Ok(value)`.
+                macro_rules! copy_try {
+                    ($result:ident) => {{
+                        let value = $result?;
+                        $result = Ok(value);
+                        value
+                    }};
+                }
+
+                // Format blob name
+                let mut blob_name = String::with_capacity(path.as_os_str().len());
+                let mut placeholder = false;
+                for part in self.blob_name.split('#') {
+                    if placeholder {
+                        let inserted = match part {
+                            "name" => copy_try!(name),
+                            "stem" => copy_try!(stem),
+                            "ext" => copy_try!(ext),
+                            other => bail!("Invalid placeholder: {other:?}"),
+                        };
+                        blob_name.push_str(inserted);
+                    } else {
+                        blob_name.push_str(part);
+                    }
+                    placeholder = !placeholder;
+                }
+
+                // Make sure the right number of #s are found
+                if !placeholder {
+                    bail!("Blob name is malformed (invalid number of #s)");
+                }
+
+                // Check if it's a duplicate
+                if blob_names.contains(&blob_name) {
+                    // Duplicate name
+                    duplicates.insert(blob_name);
+                } else {
+                    // Unique name
+                    blob_names.push(blob_name);
+                }
+
+                Ok((blob_names, duplicates))
+            },
+        )?;
+
+        // Check if we had duplicate names
+        if !duplicate_names.is_empty() {
+            // Format the names
+            let duplicate_names = Vec::from_iter(duplicate_names).join(", ");
+            bail!("Duplicate blob names: {duplicate_names}");
+        }
+
+        // Convert each input path to an action
         let credential =
             DefaultAzureCredential::new().context("Failed to get default Azure credential")?;
         let endpoint = self
@@ -59,100 +142,54 @@ impl Command for SyncFileOptions {
             .storage_account_url
             .resolve(dotenv.as_ref())?;
         let container_name = self.azure_storage.container_name.resolve(dotenv.as_ref())?;
+        let actions: FuturesUnordered<_> = paths
+            .into_iter()
+            .zip(blob_names)
+            .map(|(path, blob_name)| {
+                get_file_action(
+                    path,
+                    blob_name,
+                    credential.clone(),
+                    &endpoint,
+                    &container_name,
+                    self.sync.sync_mode,
+                )
+            })
+            .collect();
+        let mut actions: Vec<_> = actions.try_collect().await?;
+        actions.sort();
+
+        // Print actions to the user
         info!("Using:");
         info!("  Endpoint: {endpoint}");
         info!("  Container: {container_name}");
-        info!("  Blob: {blob_name}");
-        let client = BlobClient::new(
-            endpoint.as_str(),
-            container_name.into_owned(),
-            blob_name.to_owned(),
-            credential,
-            None,
-        )?;
-
-        // Open the local file
-        let file = match File::open(&local_path) {
-            Ok(file) => Some(file),
-            Err(error) => {
-                if error.kind() == ErrorKind::NotFound {
-                    None
-                } else {
-                    bail!(error);
-                }
+        info!("Actions:");
+        for action in &actions {
+            match action {
+                SyncType::Push(inner) => info!(
+                    "<- PUSH: {} <- {}",
+                    inner.context.blob_name,
+                    inner.context.local_path.display(),
+                ),
+                SyncType::Pull(inner) => info!(
+                    "-> PULL: {} -> {}",
+                    inner.context.blob_name,
+                    inner.context.local_path.display(),
+                ),
+                SyncType::Skip { reason, data } => info!(
+                    "   SKIP ({reason}): {} -- {}",
+                    data.blob_name,
+                    data.local_path.display(),
+                ),
             }
-        };
-
-        // Get the local modified time
-        let local_modified = file
-            .as_ref()
-            .map(|file| file.metadata()?.modified())
-            .transpose()?
-            .map(OffsetDateTime::from);
-
-        // Get the remote blob
-        let (remote_blob, remote_modified) = match client.download(None).await {
-            Ok(blob) => {
-                // Get when the remote blob was last modified
-                let remote_modified = blob
-                    .metadata()?
-                    .get(MODIFIED_META)
-                    .map(|time| OffsetDateTime::parse(time, &Rfc3339))
-                    .transpose()?;
-                let remote_modified = match remote_modified {
-                    Some(time) => time,
-                    None => blob
-                        .last_modified()?
-                        .context("unable to determine when blob was modified")?,
-                };
-
-                (Some(blob), Some(remote_modified))
-            }
-            Err(error) => {
-                // Only allow NotFound - fail otherwise
-                if error.http_status() != Some(StatusCode::NotFound) {
-                    bail!(error);
-                }
-
-                (None, None)
-            }
-        };
-
-        let action = SyncType::from_modified(
-            self.sync.sync_mode,
-            local_modified,
-            remote_modified,
-            remote_blob,
-            |local_modified, remote_blob| PushFile {
-                client,
-                local_path: local_path.clone(),
-                local_modified,
-                remote_etag: remote_blob.and_then(|blob| blob.etag().ok().flatten()),
-            },
-            |remote_modified, remote_blob| PullFile {
-                remote_blob: remote_blob
-                    .expect("remote blob should be Some")
-                    .into_raw_body(),
-                remote_modified,
-                local_path: local_path.clone(),
-            },
-            |_| {},
-        );
-
-        // Print actions to the user
-        info!("Action:");
-        match action {
-            SyncType::Push(_) => info!("<- PUSH"),
-            SyncType::Pull(_) => info!("-> PULL"),
-            SyncType::Skip { reason, .. } => info!("   SKIP ({reason})"),
         }
 
-        if matches!(action, SyncType::Skip { .. }) {
-            // Nothing to do
-            exit(0);
-        } else if self.sync.check_only {
-            // Do nothing, but report that we're out of sync
-            exit(1);
+        // If we're only checking, make no changes
+        let unchanged = actions
+            .iter()
+            .all(|action| matches!(action, SyncType::Skip { .. }));
+        if self.sync.check_only || unchanged {
+            exit(i32::from(!unchanged));
         }
 
         // Ask for confirmation
@@ -161,22 +198,121 @@ impl Command for SyncFileOptions {
         }
 
         // Execute the action
-        action.execute().await?;
+        let actions: FuturesUnordered<_> = actions.into_iter().map(SyncAction::execute).collect();
+        actions.try_collect::<()>().await?;
 
         Ok(())
     }
 }
 
+async fn get_file_action(
+    local_path: PathBuf,
+    blob_name: String,
+    credential: Arc<DefaultAzureCredential>,
+    endpoint: &Url,
+    container_name: &str,
+    sync_mode: SyncMode,
+) -> anyhow::Result<SyncType<PushFile, PullFile, Context>> {
+    // Open the local file
+    let file = match File::open(&local_path) {
+        Ok(file) => Some(file),
+        Err(error) => {
+            if error.kind() == ErrorKind::NotFound {
+                None
+            } else {
+                bail!(error);
+            }
+        }
+    };
+
+    // Get the local modified time
+    let local_modified = file
+        .as_ref()
+        .map(|file| file.metadata()?.modified())
+        .transpose()?
+        .map(OffsetDateTime::from);
+
+    // Open the remote blob
+    let client = BlobClient::new(
+        endpoint.as_str(),
+        container_name.to_string(),
+        blob_name.clone(),
+        credential,
+        None,
+    )?;
+    let (remote_blob, remote_modified) = match client.download(None).await {
+        Ok(blob) => {
+            // Get when the remote blob was last modified
+            let remote_modified = blob
+                .metadata()?
+                .get(MODIFIED_META)
+                .map(|time| OffsetDateTime::parse(time, &Rfc3339))
+                .transpose()?;
+            let remote_modified = match remote_modified {
+                Some(time) => time,
+                None => blob
+                    .last_modified()?
+                    .context("unable to determine when blob was modified")?,
+            };
+
+            (Some(blob), Some(remote_modified))
+        }
+        Err(error) => {
+            // Only allow NotFound - fail otherwise
+            if error.http_status() != Some(StatusCode::NotFound) {
+                bail!(error);
+            }
+
+            (None, None)
+        }
+    };
+
+    let context = Context {
+        local_path: local_path.clone(),
+        blob_name,
+    };
+    Ok(SyncType::from_modified(
+        sync_mode,
+        local_modified,
+        remote_modified,
+        remote_blob,
+        |local_modified, remote_blob| PushFile {
+            context: context.clone(),
+            client,
+            local_modified,
+            remote_etag: remote_blob.and_then(|blob| blob.etag().ok().flatten()),
+        },
+        |remote_modified, remote_blob| PullFile {
+            context: context.clone(),
+            remote_blob: remote_blob
+                .expect("remote blob should be Some")
+                .into_raw_body(),
+            remote_modified,
+        },
+        |_| context.clone(),
+    ))
+}
+
+#[derive(Clone, Debug)]
+struct Context {
+    local_path: PathBuf,
+    blob_name: String,
+}
+
+sortable_by_key!(Context, str, |context| &context.blob_name);
+
 struct PullFile {
+    context: Context,
     remote_blob: ResponseBody,
     remote_modified: OffsetDateTime,
-    local_path: PathBuf,
 }
+
+sortable_by_key!(PullFile, Context, |action| &action.context);
 
 impl SyncAction for PullFile {
     async fn execute(mut self) -> anyhow::Result<()> {
         // Save the file to disk
-        let mut file = File::create(self.local_path)?;
+        let mut file = File::create(self.context.local_path)?;
         while let Some(chunk) = self.remote_blob.try_next().await? {
             file.write_all(&chunk)?;
         }
@@ -187,15 +323,17 @@ impl SyncAction for PullFile {
 }
 
 struct PushFile {
+    context: Context,
     client: BlobClient,
-    local_path: PathBuf,
     local_modified: OffsetDateTime,
     remote_etag: Option<String>,
 }
 
+sortable_by_key!(PushFile, Context, |action| &action.context);
+
 impl SyncAction for PushFile {
     async fn execute(self) -> anyhow::Result<()> {
-        let local_file = AsyncFile::open(self.local_path).await?;
+        let local_file = AsyncFile::open(self.context.local_path).await?;
         let content_length = local_file.metadata().await?.len();
         let stream = FileStreamBuilder::new(local_file).build().await?;
         let metadata = [(

--- a/src/commands/macros.rs
+++ b/src/commands/macros.rs
@@ -1,0 +1,38 @@
+macro_rules! sortable_by_key {
+    ($ty_name:ident, $val_type:ty, |$val:ident| $field:expr) => {
+        impl ::core::cmp::PartialEq for $ty_name {
+            fn eq(&self, other: &Self) -> bool {
+                let lhs: &$val_type = match self {
+                    $val => $field,
+                };
+                let rhs: &$val_type = match other {
+                    $val => $field,
+                };
+                lhs == rhs
+            }
+        }
+
+        // Technically this forms a total equality relationship
+        impl ::core::cmp::Eq for $ty_name where $val_type: Eq {}
+
+        impl ::core::cmp::PartialOrd for $ty_name {
+            fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+                // Only compare names
+                Some(self.cmp(other))
+            }
+        }
+
+        impl ::core::cmp::Ord for $ty_name {
+            fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
+                // Technically forms a total ordering
+                let lhs: &$val_type = match self {
+                    $val => $field,
+                };
+                let rhs: &$val_type = match other {
+                    $val => $field,
+                };
+                ::core::cmp::Ord::cmp(lhs, rhs)
+            }
+        }
+    };
+}


### PR DESCRIPTION
This updates the `azsync file` subcommand to accept multiple paths.

**Changed:**

- `azsync file` accepts multiple files now (min 1)
- `--blob-name` now accepts a pattern. Normal blob names are still supported, but...
  - `#name#` is replaced with the file name (without directories)
  - `#stem#` is replaced with the name without the final extension
  - `#suffix#` is replaced with the final extension (with a leading dot), if present
  - `#ext#` is replaced with the final extension (without a leading dot), if present

**Fixed:**

- `azsync file` now checks if the blob name is empty